### PR TITLE
allow for viariable 3' i7 sequence 

### DIFF
--- a/illumiprocessor/core.py
+++ b/illumiprocessor/core.py
@@ -268,8 +268,8 @@ class TestJavaAndTrimmomatic:
 
     def test_version(self):
         version = self.get_version(self.result_split[0])
-        assert (version[:2] == ["1", "6"] or version[:2] == ["1", "7"]), \
-            "Java does not appear to be 1.6 or 1.7"
+        assert (version[:2] == ["1", "6"] or version[:2] == ["1", "7"] or version[:2] == ["1", "8"]), \
+            "Java does not appear to be 1.6 or 1.7 or 1.8"
 
     def test_trimmomatic(self, trimmomatic_pth):
         cmd = ["java", "-jar", trimmomatic_pth]

--- a/illumiprocessor/core.py
+++ b/illumiprocessor/core.py
@@ -26,6 +26,36 @@ import multiprocessing
 import pdb
 
 
+## TruSeq V2 Kit 2nd set of indexed adapters
+iFiveDict= {}
+#index 13
+iFiveDict["AGTCAA"] = 'CAATCTCGTATGCCGTCTTCTGCTTG'
+#index 14
+iFiveDict["AGTTCC"] = 'GTATCTCGTATGCCGTCTTCTGCTTG'
+#index 15
+iFiveDict["ATGTCA"] = 'GAATCTCGTATGCCGTCTTCTGCTTG'
+#index 16
+iFiveDict["CCGTCC"] = 'CGATCTCGTATGCCGTCTTCTGCTTG'
+#index 18
+iFiveDict["GTCCGC"] = 'ACATCTCGTATGCCGTCTTCTGCTTG'
+#index 19
+iFiveDict["GTGAAA"] = 'CGATCTCGTATGCCGTCTTCTGCTTG'
+#index 20
+iFiveDict["GTGGCC"] = 'TTATCTCGTATGCCGTCTTCTGCTTG'
+#index 21
+iFiveDict["GTTTCG"] = 'GAATCTCGTATGCCGTCTTCTGCTTG'
+#index 22
+iFiveDict["CGTACG"] = 'TAATCTCGTATGCCGTCTTCTGCTTG'
+#index 23
+iFiveDict["GAGTGG"] = 'ATATCTCGTATGCCGTCTTCTGCTTG'
+#index 25
+iFiveDict["ACTGAT"] = 'ATATCTCGTATGCCGTCTTCTGCTTG'
+#index 27
+iFiveDict["ATTCCT"] = 'TTATCTCGTATGCCGTCTTCTGCTTG'
+
+
+
+
 class FullPaths(argparse.Action):
     """Expand user- and relative-paths"""
     def __call__(self, parser, namespace, values, option_string=None):
@@ -128,7 +158,11 @@ class SequenceData():
         else:
             self.i7 = combo
             self.i7s = tags[self.i7]
-            self.i7a = conf.get('adapters', 'i7').replace("*", self.i7s)
+            p1, p2 = conf.get('adapters', 'i7').split('*')
+            if self.i7s in iFiveDict:
+                self.i7a = p1 + self.i7s + iFiveDict[self.i7s]
+            else:
+                self.i7a = conf.get('adapters', 'i7').replace("*", self.i7s)
             # there is no index sequence in this adapter
             if not self.se:
                 self.i5a = conf.get('adapters', 'i5')


### PR DESCRIPTION
sequence after the index/barcode in i7 adaptor sequence is not uniform for all i7 indexes 

from index-13 onwards 

```
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACCTTGTAATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 13
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACAGTCAACAATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 14
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACAGTTCCGTATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 15
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACATGTCAGAATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 16
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACCCGTCCCGATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 18
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACGTCCGCACATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 19
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACGTGAAACGATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 20
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACGTGGCCTTATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 21
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACGTTTCGGAATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 22
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACCGTACGTAATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 23
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACGAGTGGATATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 25
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACACTGATATATCTCGTATGCCGTCTTCTGCTTG
TruSeq Adapter, Index 27
5’ GATCGGAAGAGCACACGTCTGAACTCCAGTCACATTCCTTTATCTCGTATGCCGTCTTCTGCTTG
```
