### PR TITLE
Fix CLI for Conda installations in a non-default location

### DIFF
--- a/illumiprocessor/cli/main.py
+++ b/illumiprocessor/cli/main.py
@@ -19,13 +19,13 @@ from illumiprocessor import core
 
 def get_trimmomatic_path():
     try:
-        conda_env = os.environ["CONDA_DEFAULT_ENV"]
+        conda_path = os.environ["CONDA_ENV_PATH"]
     except KeyError:
-        conda_env = False
-    if conda_env is not False:
+        conda_path = False
+    if conda_path is not False:
         pth = os.path.abspath(
             os.path.expanduser(
-                "~/anaconda/envs/{}/jar/trimmomatic.jar".format(conda_env)
+                "{}/jar/trimmomatic.jar".format(conda_path)
             )
         )
     else:


### PR DESCRIPTION
This patch would allow the use of Conda installations on paths different from the default (the user home). It's required for global installations, such ones used in supercomputer centers.  
